### PR TITLE
Correct cuOpt license references

### DIFF
--- a/05_gpu_distance_calcuation.py
+++ b/05_gpu_distance_calcuation.py
@@ -519,4 +519,4 @@ display(spark.read.table(distances_table))
 # MAGIC | branca                 | Library for generating complex HTML+JS pages in Python; provides non-map-specific features for folium | MIT License  | https://github.com/python-visualization/branca            |
 # MAGIC | plotly                 | Open-source Python library for creating interactive, publication-quality charts and graphs        | MIT License  | https://github.com/plotly/plotly.py                       |
 # MAGIC ray |	Flexible, high-performance distributed execution framework for scaling Python workflows |	Apache2.0 |	https://github.com/ray-project/ray
-# MAGIC cuOpt | GPU-accelerated combinatorial optimization solver from NVIDIA | NVIDIA Proprietary (free for non-commercial use) | https://developer.nvidia.com/cuopt
+# MAGIC cuOpt | GPU-accelerated combinatorial optimization solver from NVIDIA | Apache 2.0 | https://docs.nvidia.com/cuopt/user-guide/latest/license.html

--- a/06_gpu_route_optimization.ipynb
+++ b/06_gpu_route_optimization.ipynb
@@ -1,846 +1,675 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "2fa9a5c1-06dd-469f-b92f-3985dd31486f",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Check GPU"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%sh nvidia-smi"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "0e862297-c644-465b-8b3b-d2abe1277225",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Install CuOpt"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%pip install -q folium\n",
-    "%pip install -q --extra-index-url=https://pypi.nvidia.com cuopt-server-cu12 cuopt-sh-client cuopt-cu12==25.8.*\n",
-    "%restart_python"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "835a1815-de23-48b9-824b-0a17ca51ea4f",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Set Configs"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "NUM_SHIPMENTS = 10_000\n",
-    "NUM_ROUTES = int(round(NUM_SHIPMENTS / 250 )) # total trucks available\n",
-    "MAX_EV = 4000 # max capacity\n",
-    "MAX_VAN = 8000\n",
-    "DEPOT_LAT, DEPOT_LON = 39.7685, -86.1580 # start and end point for each route\n",
-    "SOLVER_MINUTES = 10\n",
-    "\n",
-    "\n",
-    "catalog = \"default\"\n",
-    "schema = f\"routing\"\n",
-    "shipments_table = f\"{catalog}.{schema}.raw_shipments_{NUM_SHIPMENTS}\"\n",
-    "mapping_table = f\"{catalog}.{schema}.shipment_ids_map_{NUM_SHIPMENTS}\"\n",
-    "clustered_table = f\"{catalog}.{schema}.shipment_clusters_gpu_{NUM_SHIPMENTS}\"\n",
-    "distances_table = f\"{catalog}.{schema}.distances_by_route_gpu_{NUM_SHIPMENTS}\"\n",
-    "routing_table = f\"{catalog}.{schema}.routing_unified_by_cluster_gpu_{NUM_SHIPMENTS}\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "1cd04618-1a88-4512-884a-3e00ec5c844c",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Import Libraries"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import cudf\n",
-    "from cuopt import routing, distance_engine\n",
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "from pyspark.sql import functions as F"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "3abf097b-4a69-4786-bcd9-57ede27591f6",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Simple Example"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "cost = cudf.DataFrame([\n",
-    "  [0,3,1,2],\n",
-    "  [3,0,1,2],\n",
-    "  [2,3,0,2],\n",
-    "  [2,3,1,0]], dtype='float32')\n",
-    "n_locations = cost.shape[0]\n",
-    "n_vehicles = 1\n",
-    "\n",
-    "dm = routing.DataModel(n_locations, n_vehicles)\n",
-    "dm.add_cost_matrix(cost)\n",
-    "dm.add_transit_time_matrix(cost)\n",
-    "\n",
-    "ss = routing.SolverSettings()\n",
-    "ss.set_verbose_mode(True)\n",
-    "ss.set_time_limit(10)\n",
-    "sol = routing.Solve(dm, ss)\n",
-    "\n",
-    "print(sol.get_route())      # pandas-like table\n",
-    "sol.display_routes()        # pretty print "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "collapsed": true,
-     "inputWidgets": {},
-     "nuid": "29af4d8a-7b91-495a-aac1-413195065d34",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Simple Waypoint Example"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# # Hello World: cuOpt with CSR Waypoint Graph (no dense N×N)\n",
-    "\n",
-    "# import numpy as np\n",
-    "# import cudf\n",
-    "# from cuopt import distance_engine, routing\n",
-    "\n",
-    "\n",
-    "# base = np.array([\n",
-    "#     [0,3,1,2],\n",
-    "#     [3,0,1,2],\n",
-    "#     [2,3,0,2],\n",
-    "#     [2,3,1,0]\n",
-    "# ], dtype=np.float32)\n",
-    "\n",
-    "# V = base.shape[0]\n",
-    "# # Build CSR: for each src i, edges to all j != i\n",
-    "# indices = []\n",
-    "# weights = []\n",
-    "# offsets = [0]\n",
-    "# for i in range(V):\n",
-    "#     for j in range(V):\n",
-    "#         if i == j:\n",
-    "#             continue\n",
-    "#         indices.append(j)\n",
-    "#         weights.append(float(base[i, j]))\n",
-    "#     offsets.append(len(indices))\n",
-    "\n",
-    "# indices = np.asarray(indices, dtype=np.int32)        # size E = 12\n",
-    "# weights = np.asarray(weights, dtype=np.float32)      # size E\n",
-    "# offsets = np.asarray(offsets, dtype=np.int32)        # size V+1\n",
-    "\n",
-    "# # ----- 2) Build Waypoint graph and compute compact matrix for targets -----\n",
-    "# wg = distance_engine.WaypointMatrix(offsets, indices, weights)\n",
-    "# targets = np.arange(V, dtype=np.int32)               # use all 4 nodes; 0 will be the depot\n",
-    "# cost = wg.compute_cost_matrix(targets)               # cudf.DataFrame (4x4)\n",
-    "\n",
-    "# # ----- 3) Build a minimal routing model and solve -----\n",
-    "# n_locations = len(targets)\n",
-    "# n_vehicles  = 2\n",
-    "# n_orders    = 3\n",
-    "\n",
-    "# dm = routing.DataModel(n_locations, n_vehicles, n_orders)\n",
-    "\n",
-    "# # vehicles start/end at depot (index 0 in our target set)\n",
-    "# dm.set_vehicle_locations(\n",
-    "#     cudf.Series([0]*n_vehicles),   # starts\n",
-    "#     cudf.Series([0]*n_vehicles)    # ends\n",
-    "# )\n",
-    "\n",
-    "# # 3 orders at locations 1,2,3  (indices within the compact matrix)\n",
-    "# dm.set_order_locations(cudf.Series([1,2,3]))\n",
-    "\n",
-    "# # Primary matrices\n",
-    "# dm.add_cost_matrix(cost)\n",
-    "\n",
-    "# # Optional: require both vehicles to be used (just to see multiple routes)\n",
-    "# dm.set_min_vehicles(n_vehicles)\n",
-    "\n",
-    "# ss = routing.SolverSettings()\n",
-    "# ss.set_verbose_mode(True)\n",
-    "# # ss.set_time_limit(5)  # optional\n",
-    "\n",
-    "# sol = routing.Solve(dm, ss)\n",
-    "# print(sol.get_route())   # pandas-like table\n",
-    "# sol.display_routes()     # pretty print"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "c0d0bdff-1910-4114-8991-de3a74889d04",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Prepare Data"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "DEPOT_ID = 0\n",
-    "\n",
-    "distances_df = (\n",
-    "  spark.read.table(distances_table)\n",
-    "  .select(\"global_idx_source\", \"global_idx_dest\", \"duration_seconds\")\n",
-    ")\n",
-    "\n",
-    "rev_to_depot = (\n",
-    "    distances_df\n",
-    "      .where(F.col(\"global_idx_dest\") == DEPOT_ID)\n",
-    "      .select(\n",
-    "          F.lit(DEPOT_ID).alias(\"global_idx_source\"),\n",
-    "          F.col(\"global_idx_source\").alias(\"global_idx_dest\"),\n",
-    "          F.col(\"duration_seconds\")\n",
-    "      )\n",
-    ")\n",
-    "\n",
-    "distances_df = (\n",
-    "    distances_df\n",
-    "    .unionByName(rev_to_depot)\n",
-    "    # .orderBy(\"global_idx_source\", \"global_idx_dest\")\n",
-    ")\n",
-    "display(distances_df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "41f5fbbb-3821-4f2a-96fd-15b17aebe95e",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Set up Cost Matrix"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# ---------------------------\n",
-    "# 1) Pull edges and normalize\n",
-    "# ---------------------------\n",
-    "pdf = (\n",
-    "    distances_df\n",
-    "      .select(\n",
-    "          \"global_idx_source\",\n",
-    "          \"global_idx_dest\",\n",
-    "          F.round(\"duration_seconds\").cast(\"int\").alias(\"duration_seconds\")\n",
-    "      )\n",
-    "      .toPandas()\n",
-    ")\n",
-    "\n",
-    "# Build stable 0..n-1 index space for ALL nodes seen in src or dest\n",
-    "all_nodes = pd.Index(pd.unique(pd.concat([pdf[\"global_idx_source\"],\n",
-    "                                          pdf[\"global_idx_dest\"]], ignore_index=True)))\n",
-    "node2pos = {int(g): i for i, g in enumerate(all_nodes)}\n",
-    "n = len(all_nodes)\n",
-    "\n",
-    "pdf[\"src_idx\"] = pdf[\"global_idx_source\"].map(node2pos).astype(np.int32)\n",
-    "pdf[\"dst_idx\"] = pdf[\"global_idx_dest\"].map(node2pos).astype(np.int32)\n",
-    "pdf[\"cost\"]    = pdf[\"duration_seconds\"].astype(np.int32)\n",
-    "\n",
-    "# ---------------------------\n",
-    "# 2) Build CSR (offsets/indices/weights)\n",
-    "# ---------------------------\n",
-    "pdf = pdf.sort_values([\"src_idx\",\"dst_idx\"], kind=\"mergesort\")\n",
-    "\n",
-    "indices = pdf[\"dst_idx\"].to_numpy(dtype=np.int32)       # E-length array of neighbor dsts\n",
-    "weights = pdf[\"cost\"].to_numpy(dtype=np.int32)        # E-length array of edge costs\n",
-    "\n",
-    "# counts per src over the FULL 0..n-1 range (nodes with 0 out-edges still get an offset)\n",
-    "counts = (\n",
-    "    pdf.groupby(\"src_idx\").size()\n",
-    "       .reindex(range(n), fill_value=0)\n",
-    "       .to_numpy(dtype=np.int32)\n",
-    ")\n",
-    "\n",
-    "# offsets[v]..offsets[v+1]-1 slice into `indices`/`weights`\n",
-    "offsets = np.concatenate([[0], np.cumsum(counts, dtype=np.int64)]).astype(np.int32)\n",
-    "\n",
-    "# ---------------------------\n",
-    "# 3) Waypoint graph + compact matrix for selected targets\n",
-    "# ---------------------------\n",
-    "wg = distance_engine.WaypointMatrix(offsets, indices, weights)\n",
-    "order_globals = [int(x) for x in all_nodes if int(x) != DEPOT_ID]\n",
-    "\n",
-    "# Targets are the nodes we want in the compact matrix: [depot] + orders\n",
-    "targets = np.array(\n",
-    "    [node2pos[DEPOT_ID]] + [node2pos[g] for g in order_globals],\n",
-    "    dtype=np.int32\n",
-    ")\n",
-    "\n",
-    "cost = wg.compute_cost_matrix(targets)   # cudf.DataFrame (len(targets) x len(targets))\n",
-    "time = cost.copy(deep=True)              # use cost as time for now"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
-     "inputWidgets": {},
-     "nuid": "c6985aab-3aff-4773-8702-55f2145d113f",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Solve!"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# ---------------------------\n",
-    "# 4) Routing model and solve\n",
-    "# ---------------------------\n",
-    "MAX_ROUTE_SECONDS = 60*60*9 # 9 hours max route time\n",
-    "n_locations = len(targets)\n",
-    "n_orders    = len(order_globals)\n",
-    "\n",
-    "dm = routing.DataModel(n_locations, NUM_ROUTES, n_orders)\n",
-    "dm.set_vehicle_locations(cudf.Series([0]*NUM_ROUTES), cudf.Series([0]*NUM_ROUTES))\n",
-    "dm.set_order_locations(cudf.Series(np.arange(1, n_locations, dtype=np.int32)))\n",
-    "dm.set_vehicle_max_times(cudf.Series(np.full(NUM_ROUTES, MAX_ROUTE_SECONDS, dtype=np.float32)))\n",
-    "\n",
-    "# Primary matrices\n",
-    "dm.add_cost_matrix(cost)\n",
-    "dm.add_transit_time_matrix(time)\n",
-    "dm.set_min_vehicles(NUM_ROUTES)\n",
-    "\n",
-    "ss = routing.SolverSettings()\n",
-    "ss.set_verbose_mode(True)\n",
-    "ss.set_time_limit(SOLVER_MINUTES * 60)  # time limit in seconds\n",
-    "\n",
-    "sol = routing.Solve(dm, ss)\n",
-    "sol.display_routes()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "ce0ddf94-9d17-4a27-942a-e900e4b75d55",
-     "showTitle": true,
-     "tableResultSettingsMap": {},
-     "title": "Save Results"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "route_pdf = sol.get_route().to_pandas()\n",
-    "optimized_routes_df = spark.createDataFrame(route_pdf)\n",
-    "optimized_routes_df.write.mode(\"overwrite\").saveAsTable(routing_table)\n",
-    "routing_df = spark.read.table(routing_table)\n",
-    "display(routing_df)\n",
-    "\n",
-    "\n",
-    "mapping = pd.DataFrame({\n",
-    "    \"location\": np.arange(len(targets), dtype=np.int32),\n",
-    "    \"full_pos\": targets,\n",
-    "    \"global_idx\": all_nodes.take(targets)\n",
-    "})\n",
-    "\n",
-    "routes_out = route_pdf.merge(mapping, on=\"location\", how=\"left\")\n",
-    "spark.createDataFrame(routes_out).write.format(\"delta\").mode(\"overwrite\").saveAsTable(f\"{catalog}.{schema}.routes_with_ids_{NUM_SHIPMENTS}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "896ee86d-a0f9-4901-aaaf-0d03a15c797e",
-     "showTitle": false,
-     "tableResultSettingsMap": {
-      "0": {
-       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1760035542950}",
-       "filterBlob": null,
-       "queryPlanFiltersBlob": null,
-       "tableResultIndex": 0
-      }
-     },
-     "title": ""
-    }
-   },
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/plain": [
-       "Databricks visualization. Run in Databricks to view."
-      ]
-     },
-     "metadata": {
-      "application/vnd.databricks.v1.subcommand+json": {
-       "baseErrorDetails": null,
-       "bindings": {},
-       "collapsed": false,
-       "command": "%python\n__backend_agg_display_orig = display\n__backend_agg_dfs = []\ndef __backend_agg_display_new(df):\n    __backend_agg_df_modules = [\"pandas.core.frame\", \"databricks.koalas.frame\", \"pyspark.sql.dataframe\", \"pyspark.pandas.frame\", \"pyspark.sql.connect.dataframe\"]\n    if (type(df).__module__ in __backend_agg_df_modules and type(df).__name__ == 'DataFrame') or isinstance(df, list):\n        __backend_agg_dfs.append(df)\n\ndisplay = __backend_agg_display_new\n\ndef __backend_agg_user_code_fn():\n    import base64\n    exec(base64.standard_b64decode(\"cm91dGluZ19kZiA9IHNwYXJrLnJlYWQudGFibGUocm91dGluZ190YWJsZSkKZGlzcGxheShyb3V0aW5nX2RmKQ==\").decode())\n\ntry:\n    # run user code\n    __backend_agg_user_code_fn()\n\n    #reset display function\n    display = __backend_agg_display_orig\n\n    if len(__backend_agg_dfs) > 0:\n        # create a temp view\n        if type(__backend_agg_dfs[0]).__module__ == \"databricks.koalas.frame\":\n            # koalas dataframe\n            __backend_agg_dfs[0].to_spark().createOrReplaceTempView(\"DatabricksView406c78e\")\n        elif type(__backend_agg_dfs[0]).__module__ == \"pandas.core.frame\" or isinstance(__backend_agg_dfs[0], list):\n            # pandas dataframe\n            spark.createDataFrame(__backend_agg_dfs[0]).createOrReplaceTempView(\"DatabricksView406c78e\")\n        else:\n            __backend_agg_dfs[0].createOrReplaceTempView(\"DatabricksView406c78e\")\n        #run backend agg\n        display(spark.sql(\"\"\"WITH q AS (select * from DatabricksView406c78e) SELECT `truck_id`,MAX(`arrival_stamp`) `column_93d62044233` FROM q GROUP BY `truck_id`\"\"\"))\n    else:\n        displayHTML(\"dataframe no longer exists. If you're using dataframe.display(), use display(dataframe) instead.\")\n\n\nfinally:\n    spark.sql(\"drop view if exists DatabricksView406c78e\")\n    display = __backend_agg_display_orig\n    del __backend_agg_display_new\n    del __backend_agg_display_orig\n    del __backend_agg_dfs\n    del __backend_agg_user_code_fn\n\n",
-       "commandTitle": "Visualization 1",
-       "commandType": "auto",
-       "commandVersion": 0,
-       "commentThread": [],
-       "commentsVisible": false,
-       "contentSha256Hex": null,
-       "customPlotOptions": {
-        "redashChart": [
-         {
-          "key": "type",
-          "value": "CHART"
-         },
-         {
-          "key": "options",
-          "value": {
-           "alignYAxesAtZero": true,
-           "coefficient": 1,
-           "columnConfigurationMap": {
-            "x": {
-             "column": "truck_id",
-             "id": "column_93d62044231"
-            },
-            "y": [
-             {
-              "column": "arrival_stamp",
-              "id": "column_93d62044233",
-              "transform": "MAX"
-             }
-            ]
-           },
-           "dateTimeFormat": "DD/MM/YYYY HH:mm",
-           "direction": {
-            "type": "counterclockwise"
-           },
-           "error_y": {
-            "type": "data",
-            "visible": true
-           },
-           "globalSeriesType": "column",
-           "isAggregationOn": true,
-           "legend": {
-            "traceorder": "normal"
-           },
-           "missingValuesAsZero": true,
-           "numberFormat": "0,0.[00000]",
-           "percentFormat": "0[.]00%",
-           "series": {
-            "error_y": {
-             "type": "data",
-             "visible": true
-            },
-            "stacking": null
-           },
-           "seriesOptions": {
-            "column_93d62044233": {
-             "type": "column",
-             "yAxis": 0
-            }
-           },
-           "showDataLabels": false,
-           "sizemode": "diameter",
-           "sortX": true,
-           "sortY": true,
-           "swappedAxes": false,
-           "textFormat": "",
-           "useAggregationsUi": true,
-           "valuesOptions": {},
-           "version": 2,
-           "xAxis": {
-            "labels": {
-             "enabled": true
-            },
-            "type": "-"
-           },
-           "yAxis": [
-            {
-             "type": "-"
-            },
-            {
-             "opposite": true,
-             "type": "-"
-            }
-           ]
-          }
-         }
-        ]
-       },
-       "datasetPreviewNameToCmdIdMap": {},
-       "diffDeletes": [],
-       "diffInserts": [],
-       "displayType": "redashChart",
-       "error": null,
-       "errorDetails": null,
-       "errorSummary": null,
-       "errorTraceType": null,
-       "finishTime": 0,
-       "globalVars": {},
-       "guid": "",
-       "height": "auto",
-       "hideCommandCode": false,
-       "hideCommandResult": false,
-       "iPythonMetadata": null,
-       "inputWidgets": {},
-       "isLockedInExamMode": false,
-       "latestAssumeRoleInfo": null,
-       "latestUser": "a user",
-       "latestUserId": null,
-       "listResultMetadata": null,
-       "metadata": {
-        "byteLimit": 2048000,
-        "rowLimit": 10000
-       },
-       "nuid": "dfdf00a2-ce4a-47bf-aa01-6d820b598f01",
-       "origId": 0,
-       "parentHierarchy": [],
-       "pivotAggregation": null,
-       "pivotColumns": null,
-       "position": 16.5,
-       "resultDbfsErrorMessage": null,
-       "resultDbfsStatus": "INLINED_IN_TREE",
-       "results": null,
-       "showCommandTitle": false,
-       "startTime": 0,
-       "state": "input",
-       "streamStates": {},
-       "subcommandOptions": {
-        "queryPlan": {
-         "filters": [],
-         "groups": [
-          {
-           "column": "truck_id",
-           "type": "column"
-          }
-         ],
-         "selects": [
-          {
-           "column": "truck_id",
-           "type": "column"
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
           },
-          {
-           "alias": "column_93d62044233",
-           "args": [
-            {
-             "column": "arrival_stamp",
-             "type": "column"
-            }
-           ],
-           "function": "MAX",
-           "type": "function"
-          }
-         ]
+          "inputWidgets": {},
+          "nuid": "2fa9a5c1-06dd-469f-b92f-3985dd31486f",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Check GPU"
         }
-       },
-       "submitTime": 0,
-       "subtype": "tableResultSubCmd.visualization",
-       "tableResultIndex": 0,
-       "tableResultSettingsMap": {},
-       "useConsistentColors": false,
-       "version": "CommandV1",
-       "width": "auto",
-       "workflows": null,
-       "xColumns": null,
-       "yColumns": null
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "routing_df = spark.read.table(routing_table)\n",
-    "display(routing_df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "02c6283b-556a-45ac-83a0-a79a8d941553",
-     "showTitle": false,
-     "tableResultSettingsMap": {
-      "0": {
-       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1760646180078}",
-       "filterBlob": null,
-       "queryPlanFiltersBlob": null,
-       "tableResultIndex": 0
-      }
-     },
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "distances_df = spark.read.table(distances_table)\n",
-    "idx_map_df =( \n",
-    "             distances_df\n",
-    "             .select(\"origin_id\", \"global_idx_source\")\n",
-    "             .withColumnsRenamed({\"origin_id\": \"package_id\", \"global_idx_source\": \"global_idx\"})\n",
-    "             .distinct()\n",
-    ")\n",
-    "display(idx_map_df)\n",
-    "idx_map_df.count()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "2466edfc-c181-4b6f-910f-5e008f97bf92",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "raw_df = spark.read.table(shipments_table).select(\"package_id\", \"latitude\", \"longitude\")\n",
-    "display(raw_df) "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "d8778793-56a9-4c98-b641-9265e2f2ba7f",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "package_idx_coords_df = raw_df.join(idx_map_df, \"package_id\")\n",
-    "package_idx_coords_df.display()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "d26010b0-09af-48ff-9d80-3d28f30ec7b5",
-     "showTitle": false,
-     "tableResultSettingsMap": {
-      "0": {
-       "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{\"route\":101},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1760656876351}",
-       "filterBlob": null,
-       "queryPlanFiltersBlob": null,
-       "tableResultIndex": 0
-      }
-     },
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "routes_ids_df = spark.read.table(f\"{catalog}.{schema}.routes_with_ids_{NUM_SHIPMENTS}\")\n",
-    "final_routes_df = routes_ids_df.join(package_idx_coords_df, \"global_idx\")\n",
-    "final_routes_df.display()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "c916890f-8c96-4493-8599-060f11c8442b",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from pyspark.sql import functions as F, Window\n",
-    "\n",
-    "# Add route_index = visit order within each truck_id by arrival_stamp\n",
-    "w = Window.partitionBy(\"truck_id\").orderBy(\"arrival_stamp\")\n",
-    "\n",
-    "route_pdf = (\n",
-    "    final_routes_df\n",
-    "    .where(\"truck_id=0\")\n",
-    "    .withColumn(\"route_index\", F.row_number().over(w) - 1)\n",
-    "    .withColumnRenamed(\"truck_id\", \"vehicle_index\")\n",
-    "    .withColumnRenamed(\"package_id\", \"origin_id\")\n",
-    "    .select(\"vehicle_index\", \"route_index\", \"origin_id\", \"latitude\", \"longitude\")\n",
-    ").toPandas()\n",
-    "from utils.plotter import plot_route_folium\n",
-    "plot_route_folium(route_pdf)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "8d2b296b-90e3-405e-bf99-3514c73ebbc6",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "source": [
-    "\n",
-    "&copy; 2025 Databricks, Inc. All rights reserved. The source in this notebook is provided subject to the [Databricks License](https://databricks.com/db-license-source).  All included or referenced third party libraries are subject to the licenses set forth below.\n",
-    "\n",
-    "| library                | description                                                                                      | license      | source                                                    |\n",
-    "|------------------------|--------------------------------------------------------------------------------------------------|--------------|-----------------------------------------------------------|\n",
-    "| OSRM Backend Server    | High performance routing engine written in C++14 designed to run on OpenStreetMap data           | BSD 2-Clause \"Simplified\" License | https://github.com/Project-OSRM/osrm-backend              |\n",
-    "| osmnx                  | Download, model, analyze, and visualize street networks and other geospatial features from OpenStreetMap in Python | MIT License  | https://github.com/gboeing/osmnx                          |\n",
-    "| ortools                | Operations research tools developed at Google for combinatorial optimization                     | Apache License 2.0 | https://github.com/google/or-tools                        |\n",
-    "| folium                 | Visualize data in Python on interactive Leaflet.js maps                                          | MIT License  | https://github.com/python-visualization/folium            |\n",
-    "| dash                   | Python framework for building analytical web applications and dashboards; built on Flask, React, and Plotly.js | MIT License  | https://github.com/plotly/dash                            |\n",
-    "| branca                 | Library for generating complex HTML+JS pages in Python; provides non-map-specific features for folium | MIT License  | https://github.com/python-visualization/branca            |\n",
-    "| plotly                 | Open-source Python library for creating interactive, publication-quality charts and graphs        | MIT License  | https://github.com/plotly/plotly.py                       |\n",
-    "ray |\tFlexible, high-performance distributed execution framework for scaling Python workflows |\tApache2.0 |\thttps://github.com/ray-project/ray\n",
-    "cuOpt | GPU-accelerated combinatorial optimization solver from NVIDIA | NVIDIA Proprietary (free for non-commercial use) | https://developer.nvidia.com/cuopt"
-   ]
-  }
- ],
- "metadata": {
-  "application/vnd.databricks.v1+notebook": {
-   "computePreferences": {
-    "hardware": {
-     "accelerator": "A10",
-     "gpuPoolId": null,
-     "memory": null
-    }
-   },
-   "dashboards": [],
-   "environmentMetadata": {
-    "base_environment": "",
-    "environment_version": "3"
-   },
-   "inputWidgetPreferences": null,
-   "language": "python",
-   "notebookMetadata": {
-    "mostRecentlyExecutedCommandWithImplicitDF": {
-     "commandId": 7158679029052746,
-     "dataframes": [
-      "_sqldf"
-     ]
+      },
+      "source": [
+        "%sh nvidia-smi"
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
-    "pythonIndentUnit": 2
-   },
-   "notebookName": "06_gpu_route_optimization",
-   "widgets": {}
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "0e862297-c644-465b-8b3b-d2abe1277225",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Install CuOpt"
+        }
+      },
+      "source": [
+        "%pip install -q folium\n",
+        "%pip install -q --extra-index-url=https://pypi.nvidia.com cuopt-server-cu12 cuopt-sh-client cuopt-cu12==25.8.*\n",
+        "%restart_python"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "835a1815-de23-48b9-824b-0a17ca51ea4f",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Set Configs"
+        }
+      },
+      "source": [
+        "NUM_SHIPMENTS = 10_000\n",
+        "NUM_ROUTES = int(round(NUM_SHIPMENTS / 250 )) # total trucks available\n",
+        "MAX_EV = 4000 # max capacity\n",
+        "MAX_VAN = 8000\n",
+        "DEPOT_LAT, DEPOT_LON = 39.7685, -86.1580 # start and end point for each route\n",
+        "SOLVER_MINUTES = 10\n",
+        "\n",
+        "\n",
+        "catalog = \"default\"\n",
+        "schema = f\"routing\"\n",
+        "shipments_table = f\"{catalog}.{schema}.raw_shipments_{NUM_SHIPMENTS}\"\n",
+        "mapping_table = f\"{catalog}.{schema}.shipment_ids_map_{NUM_SHIPMENTS}\"\n",
+        "clustered_table = f\"{catalog}.{schema}.shipment_clusters_gpu_{NUM_SHIPMENTS}\"\n",
+        "distances_table = f\"{catalog}.{schema}.distances_by_route_gpu_{NUM_SHIPMENTS}\"\n",
+        "routing_table = f\"{catalog}.{schema}.routing_unified_by_cluster_gpu_{NUM_SHIPMENTS}\""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "1cd04618-1a88-4512-884a-3e00ec5c844c",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Import Libraries"
+        }
+      },
+      "source": [
+        "import cudf\n",
+        "from cuopt import routing, distance_engine\n",
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "from pyspark.sql import functions as F"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "3abf097b-4a69-4786-bcd9-57ede27591f6",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Simple Example"
+        }
+      },
+      "source": [
+        "cost = cudf.DataFrame([\n",
+        "  [0,3,1,2],\n",
+        "  [3,0,1,2],\n",
+        "  [2,3,0,2],\n",
+        "  [2,3,1,0]], dtype='float32')\n",
+        "n_locations = cost.shape[0]\n",
+        "n_vehicles = 1\n",
+        "\n",
+        "dm = routing.DataModel(n_locations, n_vehicles)\n",
+        "dm.add_cost_matrix(cost)\n",
+        "dm.add_transit_time_matrix(cost)\n",
+        "\n",
+        "ss = routing.SolverSettings()\n",
+        "ss.set_verbose_mode(True)\n",
+        "ss.set_time_limit(10)\n",
+        "sol = routing.Solve(dm, ss)\n",
+        "\n",
+        "print(sol.get_route())      # pandas-like table\n",
+        "sol.display_routes()        # pretty print "
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "collapsed": true,
+          "inputWidgets": {},
+          "nuid": "29af4d8a-7b91-495a-aac1-413195065d34",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Simple Waypoint Example"
+        }
+      },
+      "source": [
+        "# # Hello World: cuOpt with CSR Waypoint Graph (no dense N×N)\n",
+        "\n",
+        "# import numpy as np\n",
+        "# import cudf\n",
+        "# from cuopt import distance_engine, routing\n",
+        "\n",
+        "\n",
+        "# base = np.array([\n",
+        "#     [0,3,1,2],\n",
+        "#     [3,0,1,2],\n",
+        "#     [2,3,0,2],\n",
+        "#     [2,3,1,0]\n",
+        "# ], dtype=np.float32)\n",
+        "\n",
+        "# V = base.shape[0]\n",
+        "# # Build CSR: for each src i, edges to all j != i\n",
+        "# indices = []\n",
+        "# weights = []\n",
+        "# offsets = [0]\n",
+        "# for i in range(V):\n",
+        "#     for j in range(V):\n",
+        "#         if i == j:\n",
+        "#             continue\n",
+        "#         indices.append(j)\n",
+        "#         weights.append(float(base[i, j]))\n",
+        "#     offsets.append(len(indices))\n",
+        "\n",
+        "# indices = np.asarray(indices, dtype=np.int32)        # size E = 12\n",
+        "# weights = np.asarray(weights, dtype=np.float32)      # size E\n",
+        "# offsets = np.asarray(offsets, dtype=np.int32)        # size V+1\n",
+        "\n",
+        "# # ----- 2) Build Waypoint graph and compute compact matrix for targets -----\n",
+        "# wg = distance_engine.WaypointMatrix(offsets, indices, weights)\n",
+        "# targets = np.arange(V, dtype=np.int32)               # use all 4 nodes; 0 will be the depot\n",
+        "# cost = wg.compute_cost_matrix(targets)               # cudf.DataFrame (4x4)\n",
+        "\n",
+        "# # ----- 3) Build a minimal routing model and solve -----\n",
+        "# n_locations = len(targets)\n",
+        "# n_vehicles  = 2\n",
+        "# n_orders    = 3\n",
+        "\n",
+        "# dm = routing.DataModel(n_locations, n_vehicles, n_orders)\n",
+        "\n",
+        "# # vehicles start/end at depot (index 0 in our target set)\n",
+        "# dm.set_vehicle_locations(\n",
+        "#     cudf.Series([0]*n_vehicles),   # starts\n",
+        "#     cudf.Series([0]*n_vehicles)    # ends\n",
+        "# )\n",
+        "\n",
+        "# # 3 orders at locations 1,2,3  (indices within the compact matrix)\n",
+        "# dm.set_order_locations(cudf.Series([1,2,3]))\n",
+        "\n",
+        "# # Primary matrices\n",
+        "# dm.add_cost_matrix(cost)\n",
+        "\n",
+        "# # Optional: require both vehicles to be used (just to see multiple routes)\n",
+        "# dm.set_min_vehicles(n_vehicles)\n",
+        "\n",
+        "# ss = routing.SolverSettings()\n",
+        "# ss.set_verbose_mode(True)\n",
+        "# # ss.set_time_limit(5)  # optional\n",
+        "\n",
+        "# sol = routing.Solve(dm, ss)\n",
+        "# print(sol.get_route())   # pandas-like table\n",
+        "# sol.display_routes()     # pretty print"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "c0d0bdff-1910-4114-8991-de3a74889d04",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Prepare Data"
+        }
+      },
+      "source": [
+        "DEPOT_ID = 0\n",
+        "\n",
+        "distances_df = (\n",
+        "  spark.read.table(distances_table)\n",
+        "  .select(\"global_idx_source\", \"global_idx_dest\", \"duration_seconds\")\n",
+        ")\n",
+        "\n",
+        "rev_to_depot = (\n",
+        "    distances_df\n",
+        "      .where(F.col(\"global_idx_dest\") == DEPOT_ID)\n",
+        "      .select(\n",
+        "          F.lit(DEPOT_ID).alias(\"global_idx_source\"),\n",
+        "          F.col(\"global_idx_source\").alias(\"global_idx_dest\"),\n",
+        "          F.col(\"duration_seconds\")\n",
+        "      )\n",
+        ")\n",
+        "\n",
+        "distances_df = (\n",
+        "    distances_df\n",
+        "    .unionByName(rev_to_depot)\n",
+        "    # .orderBy(\"global_idx_source\", \"global_idx_dest\")\n",
+        ")\n",
+        "display(distances_df)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "41f5fbbb-3821-4f2a-96fd-15b17aebe95e",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Set up Cost Matrix"
+        }
+      },
+      "source": [
+        "# ---------------------------\n",
+        "# 1) Pull edges and normalize\n",
+        "# ---------------------------\n",
+        "pdf = (\n",
+        "    distances_df\n",
+        "      .select(\n",
+        "          \"global_idx_source\",\n",
+        "          \"global_idx_dest\",\n",
+        "          F.round(\"duration_seconds\").cast(\"int\").alias(\"duration_seconds\")\n",
+        "      )\n",
+        "      .toPandas()\n",
+        ")\n",
+        "\n",
+        "# Build stable 0..n-1 index space for ALL nodes seen in src or dest\n",
+        "all_nodes = pd.Index(pd.unique(pd.concat([pdf[\"global_idx_source\"],\n",
+        "                                          pdf[\"global_idx_dest\"]], ignore_index=True)))\n",
+        "node2pos = {int(g): i for i, g in enumerate(all_nodes)}\n",
+        "n = len(all_nodes)\n",
+        "\n",
+        "pdf[\"src_idx\"] = pdf[\"global_idx_source\"].map(node2pos).astype(np.int32)\n",
+        "pdf[\"dst_idx\"] = pdf[\"global_idx_dest\"].map(node2pos).astype(np.int32)\n",
+        "pdf[\"cost\"]    = pdf[\"duration_seconds\"].astype(np.int32)\n",
+        "\n",
+        "# ---------------------------\n",
+        "# 2) Build CSR (offsets/indices/weights)\n",
+        "# ---------------------------\n",
+        "pdf = pdf.sort_values([\"src_idx\",\"dst_idx\"], kind=\"mergesort\")\n",
+        "\n",
+        "indices = pdf[\"dst_idx\"].to_numpy(dtype=np.int32)       # E-length array of neighbor dsts\n",
+        "weights = pdf[\"cost\"].to_numpy(dtype=np.int32)        # E-length array of edge costs\n",
+        "\n",
+        "# counts per src over the FULL 0..n-1 range (nodes with 0 out-edges still get an offset)\n",
+        "counts = (\n",
+        "    pdf.groupby(\"src_idx\").size()\n",
+        "       .reindex(range(n), fill_value=0)\n",
+        "       .to_numpy(dtype=np.int32)\n",
+        ")\n",
+        "\n",
+        "# offsets[v]..offsets[v+1]-1 slice into `indices`/`weights`\n",
+        "offsets = np.concatenate([[0], np.cumsum(counts, dtype=np.int64)]).astype(np.int32)\n",
+        "\n",
+        "# ---------------------------\n",
+        "# 3) Waypoint graph + compact matrix for selected targets\n",
+        "# ---------------------------\n",
+        "wg = distance_engine.WaypointMatrix(offsets, indices, weights)\n",
+        "order_globals = [int(x) for x in all_nodes if int(x) != DEPOT_ID]\n",
+        "\n",
+        "# Targets are the nodes we want in the compact matrix: [depot] + orders\n",
+        "targets = np.array(\n",
+        "    [node2pos[DEPOT_ID]] + [node2pos[g] for g in order_globals],\n",
+        "    dtype=np.int32\n",
+        ")\n",
+        "\n",
+        "cost = wg.compute_cost_matrix(targets)   # cudf.DataFrame (len(targets) x len(targets))\n",
+        "time = cost.copy(deep=True)              # use cost as time for now"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {},
+          "inputWidgets": {},
+          "nuid": "c6985aab-3aff-4773-8702-55f2145d113f",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Solve!"
+        }
+      },
+      "source": [
+        "# ---------------------------\n",
+        "# 4) Routing model and solve\n",
+        "# ---------------------------\n",
+        "MAX_ROUTE_SECONDS = 60*60*9 # 9 hours max route time\n",
+        "n_locations = len(targets)\n",
+        "n_orders    = len(order_globals)\n",
+        "\n",
+        "dm = routing.DataModel(n_locations, NUM_ROUTES, n_orders)\n",
+        "dm.set_vehicle_locations(cudf.Series([0]*NUM_ROUTES), cudf.Series([0]*NUM_ROUTES))\n",
+        "dm.set_order_locations(cudf.Series(np.arange(1, n_locations, dtype=np.int32)))\n",
+        "dm.set_vehicle_max_times(cudf.Series(np.full(NUM_ROUTES, MAX_ROUTE_SECONDS, dtype=np.float32)))\n",
+        "\n",
+        "# Primary matrices\n",
+        "dm.add_cost_matrix(cost)\n",
+        "dm.add_transit_time_matrix(time)\n",
+        "dm.set_min_vehicles(NUM_ROUTES)\n",
+        "\n",
+        "ss = routing.SolverSettings()\n",
+        "ss.set_verbose_mode(True)\n",
+        "ss.set_time_limit(SOLVER_MINUTES * 60)  # time limit in seconds\n",
+        "\n",
+        "sol = routing.Solve(dm, ss)\n",
+        "sol.display_routes()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "ce0ddf94-9d17-4a27-942a-e900e4b75d55",
+          "showTitle": true,
+          "tableResultSettingsMap": {},
+          "title": "Save Results"
+        }
+      },
+      "source": [
+        "route_pdf = sol.get_route().to_pandas()\n",
+        "optimized_routes_df = spark.createDataFrame(route_pdf)\n",
+        "optimized_routes_df.write.mode(\"overwrite\").saveAsTable(routing_table)\n",
+        "routing_df = spark.read.table(routing_table)\n",
+        "display(routing_df)\n",
+        "\n",
+        "\n",
+        "mapping = pd.DataFrame({\n",
+        "    \"location\": np.arange(len(targets), dtype=np.int32),\n",
+        "    \"full_pos\": targets,\n",
+        "    \"global_idx\": all_nodes.take(targets)\n",
+        "})\n",
+        "\n",
+        "routes_out = route_pdf.merge(mapping, on=\"location\", how=\"left\")\n",
+        "spark.createDataFrame(routes_out).write.format(\"delta\").mode(\"overwrite\").saveAsTable(f\"{catalog}.{schema}.routes_with_ids_{NUM_SHIPMENTS}\")"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "896ee86d-a0f9-4901-aaaf-0d03a15c797e",
+          "showTitle": false,
+          "tableResultSettingsMap": {
+            "0": {
+              "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1760035542950}",
+              "filterBlob": null,
+              "queryPlanFiltersBlob": null,
+              "tableResultIndex": 0
+            }
+          },
+          "title": ""
+        }
+      },
+      "source": [
+        "routing_df = spark.read.table(routing_table)\n",
+        "display(routing_df)"
+      ],
+      "execution_count": 0,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "Databricks visualization. Run in Databricks to view."
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "02c6283b-556a-45ac-83a0-a79a8d941553",
+          "showTitle": false,
+          "tableResultSettingsMap": {
+            "0": {
+              "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1760646180078}",
+              "filterBlob": null,
+              "queryPlanFiltersBlob": null,
+              "tableResultIndex": 0
+            }
+          },
+          "title": ""
+        }
+      },
+      "source": [
+        "distances_df = spark.read.table(distances_table)\n",
+        "idx_map_df =( \n",
+        "             distances_df\n",
+        "             .select(\"origin_id\", \"global_idx_source\")\n",
+        "             .withColumnsRenamed({\"origin_id\": \"package_id\", \"global_idx_source\": \"global_idx\"})\n",
+        "             .distinct()\n",
+        ")\n",
+        "display(idx_map_df)\n",
+        "idx_map_df.count()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "2466edfc-c181-4b6f-910f-5e008f97bf92",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "raw_df = spark.read.table(shipments_table).select(\"package_id\", \"latitude\", \"longitude\")\n",
+        "display(raw_df) "
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "d8778793-56a9-4c98-b641-9265e2f2ba7f",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "package_idx_coords_df = raw_df.join(idx_map_df, \"package_id\")\n",
+        "package_idx_coords_df.display()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "d26010b0-09af-48ff-9d80-3d28f30ec7b5",
+          "showTitle": false,
+          "tableResultSettingsMap": {
+            "0": {
+              "dataGridStateBlob": "{\"version\":1,\"tableState\":{\"columnPinning\":{\"left\":[\"#row_number#\"],\"right\":[]},\"columnSizing\":{\"route\":101},\"columnVisibility\":{}},\"settings\":{\"columns\":{}},\"syncTimestamp\":1760656876351}",
+              "filterBlob": null,
+              "queryPlanFiltersBlob": null,
+              "tableResultIndex": 0
+            }
+          },
+          "title": ""
+        }
+      },
+      "source": [
+        "routes_ids_df = spark.read.table(f\"{catalog}.{schema}.routes_with_ids_{NUM_SHIPMENTS}\")\n",
+        "final_routes_df = routes_ids_df.join(package_idx_coords_df, \"global_idx\")\n",
+        "final_routes_df.display()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "c916890f-8c96-4493-8599-060f11c8442b",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "from pyspark.sql import functions as F, Window\n",
+        "\n",
+        "# Add route_index = visit order within each truck_id by arrival_stamp\n",
+        "w = Window.partitionBy(\"truck_id\").orderBy(\"arrival_stamp\")\n",
+        "\n",
+        "route_pdf = (\n",
+        "    final_routes_df\n",
+        "    .where(\"truck_id=0\")\n",
+        "    .withColumn(\"route_index\", F.row_number().over(w) - 1)\n",
+        "    .withColumnRenamed(\"truck_id\", \"vehicle_index\")\n",
+        "    .withColumnRenamed(\"package_id\", \"origin_id\")\n",
+        "    .select(\"vehicle_index\", \"route_index\", \"origin_id\", \"latitude\", \"longitude\")\n",
+        ").toPandas()\n",
+        "from utils.plotter import plot_route_folium\n",
+        "plot_route_folium(route_pdf)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "application/vnd.databricks.v1+cell": {
+          "cellMetadata": {
+            "byteLimit": 2048000,
+            "rowLimit": 10000
+          },
+          "inputWidgets": {},
+          "nuid": "8d2b296b-90e3-405e-bf99-3514c73ebbc6",
+          "showTitle": false,
+          "tableResultSettingsMap": {},
+          "title": ""
+        }
+      },
+      "source": [
+        "\n",
+        "&copy; 2025 Databricks, Inc. All rights reserved. The source in this notebook is provided subject to the [Databricks License](https://databricks.com/db-license-source).  All included or referenced third party libraries are subject to the licenses set forth below.\n",
+        "\n",
+        "| library                | description                                                                                      | license      | source                                                    |\n",
+        "|------------------------|--------------------------------------------------------------------------------------------------|--------------|-----------------------------------------------------------|\n",
+        "| OSRM Backend Server    | High performance routing engine written in C++14 designed to run on OpenStreetMap data           | BSD 2-Clause \"Simplified\" License | https://github.com/Project-OSRM/osrm-backend              |\n",
+        "| osmnx                  | Download, model, analyze, and visualize street networks and other geospatial features from OpenStreetMap in Python | MIT License  | https://github.com/gboeing/osmnx                          |\n",
+        "| ortools                | Operations research tools developed at Google for combinatorial optimization                     | Apache License 2.0 | https://github.com/google/or-tools                        |\n",
+        "| folium                 | Visualize data in Python on interactive Leaflet.js maps                                          | MIT License  | https://github.com/python-visualization/folium            |\n",
+        "| dash                   | Python framework for building analytical web applications and dashboards; built on Flask, React, and Plotly.js | MIT License  | https://github.com/plotly/dash                            |\n",
+        "| branca                 | Library for generating complex HTML+JS pages in Python; provides non-map-specific features for folium | MIT License  | https://github.com/python-visualization/branca            |\n",
+        "| plotly                 | Open-source Python library for creating interactive, publication-quality charts and graphs        | MIT License  | https://github.com/plotly/plotly.py                       |\n",
+        "ray |\tFlexible, high-performance distributed execution framework for scaling Python workflows |\tApache2.0 |\thttps://github.com/ray-project/ray\n",
+        "cuOpt | GPU-accelerated combinatorial optimization solver from NVIDIA | Apache 2.0 | https://docs.nvidia.com/cuopt/user-guide/latest/license.html"
+      ]
+    }
+  ],
+  "metadata": {
+    "application/vnd.databricks.v1+notebook": {
+      "computePreferences": {
+        "hardware": {
+          "accelerator": "A10",
+          "gpuPoolId": null,
+          "memory": null
+        }
+      },
+      "dashboards": [],
+      "environmentMetadata": {
+        "base_environment": "",
+        "environment_version": "3"
+      },
+      "inputWidgetPreferences": null,
+      "language": "python",
+      "notebookMetadata": {
+        "mostRecentlyExecutedCommandWithImplicitDF": {
+          "commandId": 7158679029052746,
+          "dataframes": [
+            "_sqldf"
+          ]
+        },
+        "pythonIndentUnit": 2
+      },
+      "notebookName": "06_gpu_route_optimization",
+      "widgets": {}
+    },
+    "language_info": {
+      "name": "python"
+    }
   },
-  "language_info": {
-   "name": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ To run this accelerator, clone this repo into a Databricks workspace. Execute th
 | branca                 | Library for generating complex HTML+JS pages in Python; provides non-map-specific features for folium | MIT License  | https://github.com/python-visualization/branca            |
 | plotly                 | Open-source Python library for creating interactive, publication-quality charts and graphs        | MIT License  | https://github.com/plotly/plotly.py                       |
 ray |	Flexible, high-performance distributed execution framework for scaling Python workflows |	Apache2.0 |	https://github.com/ray-project/ray
-cuOpt | GPU-accelerated combinatorial optimization solver from NVIDIA | NVIDIA Proprietary (free for non-commercial use) | https://developer.nvidia.com/cuopt
+cuOpt | GPU-accelerated combinatorial optimization solver from NVIDIA | Apache 2.0 | https://docs.nvidia.com/cuopt/user-guide/latest/license.html


### PR DESCRIPTION
## Summary
- Correct the top-level README to show cuOpt as Apache 2.0 and link to the official NVIDIA license page.
- Update the remaining notebook artifacts that still described cuOpt as proprietary so the repo is consistent.
- Keep the change scoped to documentation and notebook metadata only; there are no runtime code changes.

## Test plan
- [x] Search the repo for stale cuOpt license wording and update each incorrect reference.
- [x] Verify the remaining cuOpt license entries all show Apache 2.0 and the official license URL.